### PR TITLE
CSPify stylesheets in the same way as for javascript files

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -174,7 +174,7 @@ function handleMainDocument() {
     inlineScripts($, options.outputDir);
   }
 
-  // strip scripts into a separate file
+  // strip scripts and stylesheets into a separate file
   if (options.csp) {
     if (options.verbose) {
       console.log('Separating scripts into separate file');
@@ -205,6 +205,29 @@ function handleMainDocument() {
       el.remove();
     });
 
+    // CSPify main page by removing inline styles
+    var styles = [];
+    $(constants.CSS).each(function() {
+      var el = $(this);
+      var content = getTextContent(el);
+      // find ancestor polymer-element node
+      var parentElement = el.closest('polymer-element').get(0);
+      if (parentElement) {
+        // get element name
+        var name = $(parentElement).attr('name');
+        // build the named Polymer invocation
+        var shadowedCss = name + '::shadow';
+
+        content = content.replace(/(.+)\s*(\{[^\}]*\})/gmi, shadowedCss + ' $1 $2');
+
+        if (options.verbose) {
+          console.log(name, '->', shadowedCss);
+        }
+      }
+      styles.push(content);
+      el.remove();
+    });
+
     // join scripts with ';' to prevent breakages due to EOF semicolon insertion
     var scriptName = path.basename(options.output, '.html') + '.js';
     var scriptContent = scripts.join(';' + constants.EOL);
@@ -214,6 +237,13 @@ function handleMainDocument() {
     fs.writeFileSync(path.resolve(options.outputDir, scriptName), scriptContent, 'utf8');
     // insert out-of-lined script into document
     findScriptLocation($).append('<script src="' + scriptName + '"></script>');
+
+    // Do the same for stylesheets
+    var stylesheetName = path.basename(options.output, '.html') + '.css';
+    var stylesheetContent = styles.join(constants.EOL);
+    fs.writeFileSync(path.resolve(options.outputDir, stylesheetName), stylesheetContent, 'utf8');
+    // insert out-of-lined script into document
+    findScriptLocation($).append('<link rel="stylesheet" href="' + stylesheetName + '" />');
   }
 
   deduplicateImports($);


### PR DESCRIPTION
For use in chrome extensions, i needed to un-inline my styles into a stylesheet, just like for javascript files .. Came up with this proof of concept which works with Canary and latest versions of Polymer .. 

Opening a pull request for feedback, not sure if this is something that should be merged in the core , if so , maybe some better, more verbose configuration options would be necessary, since the csp: true option will have a different behaviour with style tags under this branch.. 