### PR TITLE
Feature/strip excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Most URLs will be automatically adjusted by the vulcanizer.
 > JSON file for additional options
 
 - Excludes: Exclude the selected urls from vulcanization (urls are still deduplicated for imports).
-- Excluded tags are stripped completely when "stripExcludes" is true. Useful for excluding local jQuery in favor of CDN.
 
 ### Example Config
 ```json
@@ -64,6 +63,9 @@ Most URLs will be automatically adjusted by the vulcanizer.
 ```
 
 ### Example: use excludes to replace a local jQuery with CDN jQuery for my-comp
+
+- Excluded tags are stripped completely when "stripExcludes" is true. Useful for excluding local jQuery in favor of CDN.
+
 #### Step 1, create config.json
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Most URLs will be automatically adjusted by the vulcanizer.
 > JSON file for additional options
 
 - Excludes: Exclude the selected urls from vulcanization (urls are still deduplicated for imports).
+- Excluded tags are stripped completely when "stripExcludes" is true. Useful for excluding local jQuery in favor of CDN.
 
 ### Example Config
 ```json
@@ -60,6 +61,39 @@ Most URLs will be automatically adjusted by the vulcanizer.
     ]
   }
 }
+```
+
+### Example: use excludes to replace a local jQuery with CDN jQuery for my-comp
+#### Step 1, create config.json
+```json
+{
+  "excludes": {
+    "scripts": [
+      "../jquery/dist/jquery.js"
+    ],
+    "stripExcludes": true
+  }
+}
+```
+#### Step 2, run vulcanize
+```bash
+vulcanize --config config.json my-comp.html
+```
+#### Step 3, create index.html where you actually use my-comp
+```html
+<!doctype html>
+<html>
+  <head>
+    <!-- loading jQuery from CDN for my-comp -->
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <!-- point to the vulcanized html -->
+    <link rel="import" href="vulcanized.html" />
+  </head>
+  <body>
+    <my-comp></my-comp>
+  </body>
+</html>
+
 ```
 
 ## Example Usage

--- a/bin/vulcanize
+++ b/bin/vulcanize
@@ -28,6 +28,7 @@ var help = [
   '      "imports": [ "regex-to-exclude" ],',
   '      "styles": [ "regex-to-exclude" ],',
   '      "scripts": [ "regex-to-exclude" ],',
+  '      "stripExcludes": [ "boolean" ],',
   '    }',
   '  }'
 ];

--- a/lib/optparser.js
+++ b/lib/optparser.js
@@ -16,7 +16,8 @@ function processOptions(options, callback) {
   var excludes = {
     imports: [ABS_URL],
     scripts: [ABS_URL],
-    styles: [ABS_URL]
+    styles: [ABS_URL],
+    stripExcludes: false
   };
 
   if (options.config) {
@@ -57,6 +58,9 @@ function processOptions(options, callback) {
         e.styles.forEach(function(r) {
           excludes.styles.push(new RegExp(r));
         });
+      }
+      if (typeof e.stripExcludes !== 'undefined') {
+        excludes.stripExcludes = e.stripExcludes;
       }
     } catch(_) {
       return callback('Malformed import exclude config');

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -72,6 +72,9 @@ function inlineSheets($, inputPath, outputPath) {
       styleDoc('style').attr('href', null);
       styleDoc('style').attr('rel', null);
       el.replaceWith(styleDoc.html());
+    } else if ( href && excludeStyle(href) && options.excludes.stripExcludes) {
+      //completely remove the excluded style tag
+      el.replaceWith('');
     }
   });
 }
@@ -86,6 +89,9 @@ function inlineScripts($, dir) {
       // NOTE: reusing UglifyJS's inline script printer (not exported from OutputStream :/)
       content = content.replace(/<\x2fscript([>\/\t\n\f\r ])/gi, "<\\/script$1");
       el.replaceWith('<script>' + content + '</script>');
+    } else if ( src && excludeScript(src) && options.excludes.stripExcludes) {
+      //completely remove the excluded script tag
+      el.replaceWith('');
     }
   });
 }
@@ -121,6 +127,9 @@ function processImports($, mainDoc) {
         importContent = '<div hidden>' + importContent + '</div>';
       }
       el.replaceWith(importContent);
+    } else if ( href && excludeImport(href) && options.excludes.stripExcludes) {
+      //completely remove the excluded html import tag
+      el.replaceWith('');
     }
   });
 }

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -72,7 +72,7 @@ function inlineSheets($, inputPath, outputPath) {
       styleDoc('style').attr('href', null);
       styleDoc('style').attr('rel', null);
       el.replaceWith(styleDoc.html());
-    } else if ( href && excludeStyle(href) && options.excludes.stripExcludes) {
+    } else if (href && excludeStyle(href) && options.excludes.stripExcludes) {
       //completely remove the excluded style tag
       el.replaceWith('');
     }
@@ -89,7 +89,7 @@ function inlineScripts($, dir) {
       // NOTE: reusing UglifyJS's inline script printer (not exported from OutputStream :/)
       content = content.replace(/<\x2fscript([>\/\t\n\f\r ])/gi, "<\\/script$1");
       el.replaceWith('<script>' + content + '</script>');
-    } else if ( src && excludeScript(src) && options.excludes.stripExcludes) {
+    } else if (src && excludeScript(src) && options.excludes.stripExcludes) {
       //completely remove the excluded script tag
       el.replaceWith('');
     }
@@ -127,7 +127,7 @@ function processImports($, mainDoc) {
         importContent = '<div hidden>' + importContent + '</div>';
       }
       el.replaceWith(importContent);
-    } else if ( href && excludeImport(href) && options.excludes.stripExcludes) {
+    } else if (href && excludeImport(href) && options.excludes.stripExcludes) {
       //completely remove the excluded html import tag
       el.replaceWith('');
     }


### PR DESCRIPTION
- Add "stripExcludes" option in config.json
- Excluded tags are stripped completely when "stripExcludes" is true.
- Useful for excluding local jQuery in favor of CDN.
- CLA signed but it might take a while to process