### PR TITLE
Allow passing in options directly to lib/vulcan.

### DIFF
--- a/bin/vulcanize
+++ b/bin/vulcanize
@@ -13,6 +13,7 @@ var path = require('path');
 var fs = require('fs');
 var nopt = require('nopt');
 var vulcan = require('../lib/vulcan.js');
+var optparser = require('../lib/optparser.js');
 
 var help = [
   'vulcanize: Concatenate a set of Web Components into one file',
@@ -47,7 +48,7 @@ function printHelp() {
   process.exit(0);
 }
 
-var options = nopt(
+var optHash = nopt(
   {
     'config': path,
     'csp': Boolean,
@@ -66,20 +67,20 @@ var options = nopt(
   }
 );
 
-if (options.help || process.argv.length === 2) {
+if (optHash.help || process.argv.length === 2) {
   printHelp();
 }
 
-var argv = options.argv.remain;
+var argv = optHash.argv.remain;
 
 if (argv[0]) {
-  options.input = path.resolve(argv[0]);
+  optHash.input = path.resolve(argv[0]);
 }
 
-vulcan.setOptions(options, function(err) {
+optparser.processOptions(optHash, function(err, options) {
   if (err) {
     console.error(err);
     process.exit(1);
   }
-  vulcan.processDocument();
+  vulcan.processDocument(options);
 });

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -12,7 +12,6 @@ var uglify = require('uglify-js');
 var url = require('url');
 
 var constants = require('./constants.js');
-var optparser = require('./optparser.js');
 var pathresolver = require('./pathresolver');
 var utils = require('./utils');
 var setTextContent = utils.setTextContent;
@@ -22,7 +21,6 @@ var getTextContent = utils.getTextContent;
 var render = require('dom-serializer');
 
 var read = {};
-var options = {};
 
 // non-modifying HTML parsing rules for cheerio
 var CHEERIO_OPTIONS = {
@@ -31,32 +29,21 @@ var CHEERIO_OPTIONS = {
   decodeEntities: false
 };
 
-// validate options with boolean return
-function setOptions(optHash, callback) {
-  optparser.processOptions(optHash, function(err, o) {
-    if (err) {
-      return callback(err);
-    }
-    options = o;
-    callback();
-  });
-}
-
 function exclude(regexes, href) {
   return regexes.some(function(r) {
     return r.test(href);
   });
 }
 
-function excludeImport(href) {
+function excludeImport(options, href) {
   return exclude(options.excludes.imports, href);
 }
 
-function excludeScript(href) {
+function excludeScript(options, href) {
   return exclude(options.excludes.scripts, href);
 }
 
-function excludeStyle(href) {
+function excludeStyle(options, href) {
   return exclude(options.excludes.styles, href);
 }
 
@@ -66,11 +53,11 @@ function readFile(file) {
 }
 
 // inline relative linked stylesheets into <style> tags
-function inlineSheets($, inputPath, outputPath) {
+function inlineSheets(options, $, inputPath, outputPath) {
   $('link[rel="stylesheet"]').each(function() {
     var el = $(this);
     var href = el.attr('href');
-    if (href && !excludeStyle(href)) {
+    if (href && !excludeStyle(options, href)) {
       var filepath = path.resolve(options.outputDir, href);
       // fix up paths in the stylesheet to be relative to the location of the style
       var content = pathresolver.rewriteURL(path.dirname(filepath), outputPath, readFile(filepath));
@@ -85,11 +72,11 @@ function inlineSheets($, inputPath, outputPath) {
   });
 }
 
-function inlineScripts($, dir) {
+function inlineScripts(options, $, dir) {
   $(constants.JS_SRC).each(function() {
     var el = $(this);
     var src = el.attr('src');
-    if (src && !excludeScript(src)) {
+    if (src && !excludeScript(options, src)) {
       var filepath = path.resolve(dir, src);
       var content = readFile(filepath);
       // NOTE: reusing UglifyJS's inline script printer (not exported from OutputStream :/)
@@ -99,14 +86,14 @@ function inlineScripts($, dir) {
   });
 }
 
-function concat(filename) {
+function concat(options, filename) {
   if (!read[filename]) {
     read[filename] = true;
     var $ = cheerio.load(readFile(filename), CHEERIO_OPTIONS);
     var dir = path.dirname(filename);
     pathresolver.resolvePaths($, dir, options.outputDir);
-    processImports($);
-    inlineSheets($, dir, options.outputDir);
+    processImports(options, $);
+    inlineSheets(options, $, dir, options.outputDir);
     // NOTE: work-around dom-serializer
     // return $.html();
     return render($._root.children, CHEERIO_OPTIONS);
@@ -117,12 +104,12 @@ function concat(filename) {
   }
 }
 
-function processImports($, mainDoc) {
+function processImports(options, $, mainDoc) {
   $(constants.IMPORTS).each(function() {
     var el = $(this);
     var href = el.attr('href');
-    if (!excludeImport(href)) {
-      var importContent = concat(path.resolve(options.outputDir, href));
+    if (!excludeImport(options, href)) {
+      var importContent = concat(options, path.resolve(options.outputDir, href));
       // hide import content in the main document
       if (mainDoc) {
         importContent = '<div hidden>' + importContent + '</div>';
@@ -170,7 +157,7 @@ function removeCommentsAndWhitespace($) {
   $('*').contents().filter(isCommentOrEmptyTextNode).remove();
 }
 
-function writeFileSync(filename, data, eof) {
+function writeFileSync(options, filename, data, eof) {
   if (!options.outputSrc) {
     fs.writeFileSync(filename, data, 'utf8');
   } else {
@@ -178,20 +165,20 @@ function writeFileSync(filename, data, eof) {
   }
 }
 
-function handleMainDocument() {
+function handleMainDocument(options) {
   // reset shared buffers
   read = {};
   var content = options.inputSrc ? options.inputSrc.toString() : readFile(options.input);
   var $ = cheerio.load(content, CHEERIO_OPTIONS);
   var dir = path.dirname(options.input);
   pathresolver.resolvePaths($, dir, options.outputDir);
-  processImports($, true);
+  processImports(options, $, true);
   if (options.inline) {
-    inlineSheets($, dir, options.outputDir);
+    inlineSheets(options, $, dir, options.outputDir);
   }
 
   if (options.inline) {
-    inlineScripts($, options.outputDir);
+    inlineScripts(options, $, options.outputDir);
   }
 
   $(constants.JS_INLINE).each(function() {
@@ -244,26 +231,32 @@ function handleMainDocument() {
     });
 
     // join scripts with ';' to prevent breakages due to EOF semicolon insertion
-    var scriptName = path.basename(options.output, '.html') + '.js';
+    var scriptName;
+    if (options.output) {
+      scriptName = path.basename(options.output, '.html') + '.js';
+    }
+    else {
+      scriptName = 'scripts.js';
+    }
     var scriptContent = scripts.join(';' + constants.EOL);
     if (options.strip) {
       scriptContent = compressJS(scriptContent, false);
     }
-    writeFileSync(path.resolve(options.outputDir, scriptName), scriptContent);
+    writeFileSync(options, path.resolve(options.outputDir, scriptName), scriptContent);
     // insert out-of-lined script into document
     findScriptLocation($).append('<script src="' + scriptName + '"></script>');
   }
 
-  deduplicateImports($);
+  deduplicateImports(options, $);
 
   if (options.strip) {
     removeCommentsAndWhitespace($);
   }
 
-  writeFileSync(options.output, render($._root.children, CHEERIO_OPTIONS), true);
+  writeFileSync(options, options.output, render($._root.children, CHEERIO_OPTIONS), true);
 }
 
-function deduplicateImports($) {
+function deduplicateImports(options, $) {
   var imports = {};
   $(constants.IMPORTS).each(function() {
     var el = $(this);
@@ -282,4 +275,3 @@ function deduplicateImports($) {
 }
 
 exports.processDocument = handleMainDocument;
-exports.setOptions = setOptions;


### PR DESCRIPTION
This allows separating the engine from the CLI for tools (such as spock)
that want to write files in a different manner or not at all, e.g. for
streaming into later processors in a gulp build step.