### PR TITLE
Remove unused script name of CSP config

### DIFF
--- a/lib/optparser.js
+++ b/lib/optparser.js
@@ -78,9 +78,6 @@ function processOptions(options, callback) {
   options.outputDir = path.dirname(options.output);
 
   options.csp = options.csp || config.csp;
-  if (options.csp) {
-    options.csp = options.output.replace(/\.html$/, '.js');
-  }
 
   options.abspath = options.abspath || config.abspath;
   if (options.abspath) {

--- a/test/test.js
+++ b/test/test.js
@@ -298,7 +298,7 @@ suite('Optparser', function() {
 
   test('CSP', function(done) {
     optParserTest(function(err, options) {
-      assert.equal(options.csp, path.resolve('vulcanized.js'));
+      assert(options.csp);
       done();
     }, {input: 'index.html', csp: true});
   });
@@ -306,7 +306,7 @@ suite('Optparser', function() {
   test('output', function(done) {
     optParserTest(function(err, options) {
       assert.equal(options.output, path.resolve('build.html'));
-      assert.equal(options.csp, path.resolve('build.js'));
+      assert(options.csp);
       done();
     }, {input: path.resolve('index.html'), output: path.resolve('build.html'), csp: true});
   });
@@ -338,7 +338,7 @@ suite('Optparser', function() {
     optParserTest(function(err, options) {
       assert.equal(options.input, path.resolve('index.html'));
       assert.equal(options.output, path.resolve('build.html'));
-      assert.equal(options.csp, path.resolve('build.js'));
+      assert(options.csp);
       assert(!options.abspath);
       assert.deepEqual(options.excludes, {imports:[/.*/, ABS_URL], scripts:[ABS_URL], styles:[ABS_URL]});
 done();


### PR DESCRIPTION
CSP options doesn't need to have filename replaced. It's a duplicate job with https://github.com/Polymer/vulcanize/blob/master/lib/vulcan.js#L310