### PR TITLE
Don't strip white space; rather collapse to a single space.

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -175,7 +175,7 @@ function findScriptLocation($) {
   return pos;
 }
 
-function isCommentOrEmptyTextNode(node) {
+function isComment(node) {
   var d = node.data;
   if (node.type === 'comment') {
     var keep = (/@license/.test(d));
@@ -183,9 +183,6 @@ function isCommentOrEmptyTextNode(node) {
       comments.set(d);
     }
     return !keep;
-  } else if (node.type === 'text') {
-    // return true if the node is only whitespace
-    return !((/\S/).test(d));
   }
 }
 
@@ -228,9 +225,16 @@ function removeCommentsAndWhitespace($) {
     var content, c;
     if (!node) {
       return;
-    } else if (isCommentOrEmptyTextNode(node)) {
+    } else if (isComment(node)) {
       $(node).remove();
       return true;
+    } else if (node.type == 'text') {
+      var parent = node.parent;
+      // collapse whitespace unless it's inside a pre or textarea tag
+      if (['pre', 'textarea'].indexOf(parent.name) === -1) {
+        // define whitespace characters explicitly; \s is too aggressive
+        node.data = node.data.replace(/[ \r\n\t]+/g, ' ');
+      }
     } else if (node.type == 'script') {
       // only run uglify on inline javascript scripts
       if (!node.attribs.src && (!node.attribs.type || node.attribs.type == "text/javascript")) {

--- a/test/test.js
+++ b/test/test.js
@@ -575,9 +575,17 @@ suite('Vulcan', function() {
       });
     });
 
+    test('whitespace', function(done) {
+      process({inputSrc: '<div>\n  <div>\n    hi&nbsp;&nbsp;\n    </div>\n</div>  <textarea>\t\tSome text\n  \t</textarea>', output: outputPath, strip: true}, function(outputs) {
+        var vulcanized = outputs[outputPath];
+        assert.equal(vulcanized, '<html><head></head><body><div> <div> hi&nbsp;&nbsp; </div> </div> <textarea>\t\tSome text\n  \t</textarea></body></html>');
+        done();
+      });
+    });
+
     suite('css', function() {
 
-      test('precsision', function(done) {
+      test('precision', function(done) {
         process({inputSrc: '<style>test{ -ms-flex: 0 0 0.0000000001px; }</style>', output: outputPath, strip: true}, function(outputs) {
           var vulcanized = outputs[outputPath];
           assert(vulcanized);


### PR DESCRIPTION
This is a potential fix for https://github.com/Polymer/vulcanize/issues/63 which has been an irritant to me and my team for some time.

Rather than removing empty text nodes, consecutive white space in text nodes is replaced with a single space—more like what is specified in the HTML spec.

I see two main deficiencies with what I'm submitting here:

1. White space in `pre` and `textarea` elements isn't collapsed, but there may be other elements that deserve the same exception, and, in fact, the CSS `white-space` rule can be used to make white space significant for any element. @azakus' suggestion in https://github.com/Polymer/vulcanize/issues/63#issue-41528475 is a solution to this problem.

  The current approach of removing all text nodes that consist only of white space is no better in this regard.

2. If a text node ends with a space and the next node is a text node that begins with a space, those consecutive white space characters won't get collapsed. Instead, consecutive white space characters appear in the vulcanized output. This wouldn't be terribly hard to fix, but I don't think it's a big deal. I opted to keep this pull request simple, but I'll fix it if requested.