### PR TITLE
Always use POSIX-style path functions to keep slashes intact.

### DIFF
--- a/lib/pathresolver.js
+++ b/lib/pathresolver.js
@@ -59,7 +59,7 @@ function resolvePaths(importDoc, importUrl, mainDocUrl) {
   for (i = 0, node; i < domModules.length; i++) {
     node = domModules[i];
     var assetPathUrl = rewriteRelPath(importUrl, mainDocUrl, '');
-    assetPathUrl = path.dirname(assetPathUrl) + '/';
+    assetPathUrl = path.posix.dirname(assetPathUrl) + '/';
     dom5.setAttribute(node, 'assetpath', assetPathUrl);
   }
 }
@@ -79,7 +79,7 @@ function rewriteRelPath(importUrl, mainDocUrl, relUrl) {
   var parsedFrom = url.parse(mainDocUrl);
   var parsedTo = url.parse(absUrl);
   if (parsedFrom.protocol === parsedTo.protocol && parsedFrom.host === parsedTo.host) {
-    var pathname = path.relative(path.dirname(parsedFrom.pathname), parsedTo.pathname);
+    var pathname = path.posix.relative(path.posix.dirname(parsedFrom.pathname), parsedTo.pathname);
     return url.format({
       pathname: pathname,
       search: parsedTo.search,


### PR DESCRIPTION
This is a simple fix for #195. I have confirmed this resolves the issue on Windows.