### PR TITLE
fix process function

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -51,7 +51,7 @@ function buildLoader(abspath, excludes) {
 var Vulcan = function Vulcan(opts) {
     // implicitStrip should be true by default
   this.implicitStrip = opts.implicitStrip === undefined ? true : Boolean(opts.implicitStrip);
-  this.abspath = (String(opts.abspath) === opts.abspath && (opts.abspath!==null && String(opts.abspath).trim()!=='')) ? path.resolve(opts.abspath) : '';
+  this.abspath = (String(opts.abspath) === opts.abspath && String(opts.abspath).trim() !== '') ? path.resolve(opts.abspath) : '';
   this.pathResolver = new PathResolver(this.abspath);
   this.excludes = Array.isArray(opts.excludes) ? opts.excludes : [];
   this.stripExcludes = Array.isArray(opts.stripExcludes) ? opts.stripExcludes : [];

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -51,7 +51,7 @@ function buildLoader(abspath, excludes) {
 var Vulcan = function Vulcan(opts) {
     // implicitStrip should be true by default
   this.implicitStrip = opts.implicitStrip === undefined ? true : Boolean(opts.implicitStrip);
-  this.abspath = String(opts.abspath) === opts.abspath ? path.resolve(opts.abspath) : '';
+  this.abspath = (String(opts.abspath) === opts.abspath && (opts.abspath!=null && opts.abspath.toString()!='')) ? path.resolve(opts.abspath) : '';
   this.pathResolver = new PathResolver(this.abspath);
   this.excludes = Array.isArray(opts.excludes) ? opts.excludes : [];
   this.stripExcludes = Array.isArray(opts.stripExcludes) ? opts.stripExcludes : [];
@@ -330,7 +330,7 @@ Vulcan.prototype = {
     if (this.inputUrl) {
       this._process(this.inputUrl, cb);
     } else {
-      if (this.abspath!=null && this.abspath!='' && this.abspath) {
+      if (this.abspath) {
         target = pathPosix.resolve('/', target);
       } else {
         target = this.pathResolver.pathToUrl(path.resolve(target));

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -51,7 +51,7 @@ function buildLoader(abspath, excludes) {
 var Vulcan = function Vulcan(opts) {
     // implicitStrip should be true by default
   this.implicitStrip = opts.implicitStrip === undefined ? true : Boolean(opts.implicitStrip);
-  this.abspath = (String(opts.abspath) === opts.abspath && (opts.abspath!=null && opts.abspath.toString()!='')) ? path.resolve(opts.abspath) : '';
+  this.abspath = (String(opts.abspath) === opts.abspath && (opts.abspath!==null && String(opts.abspath).trim()!=='')) ? path.resolve(opts.abspath) : '';
   this.pathResolver = new PathResolver(this.abspath);
   this.excludes = Array.isArray(opts.excludes) ? opts.excludes : [];
   this.stripExcludes = Array.isArray(opts.stripExcludes) ? opts.stripExcludes : [];

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -330,7 +330,7 @@ Vulcan.prototype = {
     if (this.inputUrl) {
       this._process(this.inputUrl, cb);
     } else {
-      if (this.abspath) {
+      if (this.abspath!=null && this.abspath!='' && this.abspath) {
         target = pathPosix.resolve('/', target);
       } else {
         target = this.pathResolver.pathToUrl(path.resolve(target));


### PR DESCRIPTION
The change in the code is proposed because you should be able to pass an empty string and it process as null.  Plus the issue is some site showing how to use the function, for gulp for example, https://www.npmjs.com/package/gulp-vulcanize, show it as an empty string.  

The better way would be to trim the sides of whitespace so you could do  ' ' and it still return null.