### PR TITLE
Escape inline scripts

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -20,6 +20,7 @@ var CommentMap = require('./comment-map');
 var constants = require('./constants');
 var matchers = require('./matchers');
 var PathResolver = require('./pathresolver');
+var encodeString = require('../third_party/UglifyJS2/output');
 
 var Promise = global.Promise || require('es6-promise').Promise;
 
@@ -265,6 +266,7 @@ Vulcan.prototype = {
       }
       return this.loader.request(uri).then(function(content) {
         if (content) {
+          content = encodeString(content);
           dom5.removeAttribute(script, 'src');
           dom5.setTextContent(script, content);
         }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "path-posix": "^1.0.0"
   },
   "devDependencies": {
+    "chai": "^3.4.1",
     "jshint": "^2.7.0",
     "mocha": "^2.2.4"
   },

--- a/test/html/xss.html
+++ b/test/html/xss.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<!--
+Sample taken from https://gist.github.com/TimothyGu/f5d7c86d248de4ed08a2
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Sample XSS</title>
+</head>
+<body>
+  <script src="xss.js"></script>
+</body>
+</html>

--- a/test/html/xss.js
+++ b/test/html/xss.js
@@ -1,0 +1,11 @@
+/**
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+var b = 0</script><script>alert('XSS'); //2;

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 // jshint node: true
-var assert = require('assert');
+var chai = require('chai');
 var path = require('path');
 
 var dom5 = require('dom5');
@@ -21,7 +21,9 @@ function serialize(ast) {
   return dom5.serialize(ast);
 }
 
-assert.AssertionError.prototype.showDiff = true;
+chai.config.showDiff = true;
+
+var assert = chai.assert;
 
 suite('constants', function() {
   var constants = require('../lib/constants.js');
@@ -691,6 +693,18 @@ suite('Vulcan', function() {
         done();
       };
       process(target, callback, options);
+    });
+
+    test('Escape inline <script>', function(done) {
+      var callback = function(err, doc) {
+        if (err) {
+          return done(err);
+        }
+        var script = dom5.query(doc, matchers.JS_INLINE);
+        assert.include(dom5.getTextContent(script), 'var b = 0<\\/script><script>alert(\'XSS\'); //2;', 'Inline <script> should be escaped');
+        done();
+      };
+      process('test/html/xss.html', callback, options);
     });
   });
 

--- a/third_party/UglifyJS2/LICENSE
+++ b/third_party/UglifyJS2/LICENSE
@@ -1,0 +1,29 @@
+UglifyJS is released under the BSD license:
+
+Copyright 2012-2013 (c) Mihai Bazon <mihai.bazon@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS” AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/third_party/UglifyJS2/README.md
+++ b/third_party/UglifyJS2/README.md
@@ -1,0 +1,17 @@
+# Contents
+Slim copy of [UglifyJS2](https://github.com/mishoo/UglifyJS2) output library.
+
+# Original Copy
+https://raw.githubusercontent.com/mishoo/UglifyJS2/v2.6.1/lib/output.js
+
+# Modifications
+
+- Removed all functions except `encode_string`.
+- Replaced call `var ret = make_string(str, quote)` with `var ret = str`
+- Added default `options` object
+- Added CommonJS `module.exports` line
+- Added `jshint` settins line
+- Removed semicolon from defintion of `encode_string`
+
+# License
+BSD-2-Clause: [License](https://raw.githubusercontent.com/mishoo/UglifyJS2/v2.6.1/LICENSE)

--- a/third_party/UglifyJS2/output.js
+++ b/third_party/UglifyJS2/output.js
@@ -1,0 +1,62 @@
+/***********************************************************************
+
+  A JavaScript tokenizer / parser / beautifier / compressor.
+  https://github.com/mishoo/UglifyJS2
+
+  -------------------------------- (C) ---------------------------------
+
+                           Author: Mihai Bazon
+                         <mihai.bazon@gmail.com>
+                       http://mihai.bazon.net/blog
+
+  Distributed under the BSD license:
+
+    Copyright 2012 (c) Mihai Bazon <mihai.bazon@gmail.com>
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+        * Redistributions of source code must retain the above
+          copyright notice, this list of conditions and the following
+          disclaimer.
+
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials
+          provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS” AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+    PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+    THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+
+ ***********************************************************************/
+
+// jshint node: true
+
+"use strict";
+
+var options = {
+  inline_script: true
+};
+
+function encode_string(str, quote) {
+  var ret = str;
+  if (options.inline_script) {
+    ret = ret.replace(/<\x2fscript([>\/\t\n\f\r ])/gi, "<\\/script$1");
+    ret = ret.replace(/\x3c!--/g, "\\x3c!--");
+    ret = ret.replace(/--\x3e/g, "--\\x3e");
+  }
+  return ret;
+}
+
+module.exports = encode_string;


### PR DESCRIPTION
Use portion of UglifyJS2 to handle escaping inline-scripts
Modified UglifyJS2 located in third_party/UglifyJS2/output.js
Modifications listed in third_party/UglifyJS2/README.md

Added test case from @TimothyGu
Use chai for assert testing

Fixes #280