### PR TITLE
Fix ordering of import dependencies once and for all

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ vulcan.process(target, function(err, inlinedHtml) {
 });
 ```
 
+## Caveats
+
+Because HTML Imports changes the order of execution scripts can have, Vulcanize
+has to make a few compromises to achieve that same script execution order.
+
+1. Contents of all HTML Import documents will be moved to `<body>`
+
+1. Any scripts after a `<link rel="import">` node in `<head>` will be moved to `<body>` after the contents of the HTML Import.
+
 ## What happened to [feature] from 0.X?
 - `--csp` mode has been moved into [crisper](https://github.com/PolymerLabs/crisper)
 - `--strip` mode was removed, use something like [html-minifier](https://github.com/kangax/html-minifier) or [minimize](https://github.com/Moveo/minimize)

--- a/lib/matchers.js
+++ b/lib/matchers.js
@@ -79,6 +79,10 @@ module.exports = {
   polymerElement: p.hasTagName('polymer-element'),
   urlAttrs: urlAttrs,
   targetMatcher: targetMatcher,
+  IMPORT: p.AND(
+      p.hasTagName('link'),
+      p.hasAttrValue('rel', 'import')
+  ),
   JS: jsMatcher,
   CSS: styleMatcher,
   CSS_LINK: externalStyle,

--- a/lib/matchers.js
+++ b/lib/matchers.js
@@ -79,10 +79,6 @@ module.exports = {
   polymerElement: p.hasTagName('polymer-element'),
   urlAttrs: urlAttrs,
   targetMatcher: targetMatcher,
-  IMPORT: p.AND(
-      p.hasTagName('link'),
-      p.hasAttrValue('rel', 'import')
-  ),
   JS: jsMatcher,
   CSS: styleMatcher,
   CSS_LINK: externalStyle,

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -216,9 +216,14 @@ Vulcan.prototype = {
         // merge head and body tags for imports into main document
         var importHeadChildren = importHead.childNodes;
         var importBodyChildren = importBody.childNodes;
-        // replace link in head with head elements from import
-        this.replaceWith(head, importNodes[i], importHeadChildren);
-        // defer body children to be inlined in-order
+        // delete link in head
+        this.removeImportAndNewline(importNodes[i]);
+        // defer head and body children to be inlined in-order
+        if (importHeadChildren.length) {
+          this.pathResolver.resolvePaths(importHead, tree.href, mainDocUrl);
+          importHeadChildren.forEach(this.reparent(bodyFragment));
+          bodyFragment.childNodes = bodyFragment.childNodes.concat(importHeadChildren);
+        }
         if (importBodyChildren.length) {
           // adjust body urls to main document
           this.pathResolver.resolvePaths(importBody, tree.href, mainDocUrl);
@@ -226,21 +231,6 @@ Vulcan.prototype = {
           bodyFragment.childNodes = bodyFragment.childNodes.concat(importBodyChildren);
         }
       }
-    }
-    if (this.stripComments) {
-      var comments = new CommentMap();
-      // remove all comments
-      dom5.nodeWalkAll(doc, dom5.isCommentNode).forEach(function(comment) {
-        comments.set(comment.data, comment);
-        dom5.remove(comment);
-      });
-      // Deduplicate license comments
-      comments.keys().forEach(function (commentData) {
-        if (commentData.indexOf("@license") == -1) {
-          return;
-        }
-        this.prepend(head, comments.get(commentData));
-      }.bind(this));
     }
     return doc;
   },
@@ -389,6 +379,27 @@ Vulcan.prototype = {
     if (this.enableCssInlining) {
       chain = chain.then(function(docObj) {
         return this.inlineCss(docObj.doc, docObj.href);
+      }.bind(this));
+    }
+
+    if (this.stripComments) {
+      chain = chain.then(function(docObj) {
+        var comments = new CommentMap();
+        var doc = docObj.doc;
+        var head = dom5.query(doc, matchers.head);
+        // remove all comments
+        dom5.nodeWalkAll(doc, dom5.isCommentNode).forEach(function(comment) {
+          comments.set(comment.data, comment);
+          dom5.remove(comment);
+        });
+        // Deduplicate license comments
+        comments.keys().forEach(function (commentData) {
+          if (commentData.indexOf("@license") == -1) {
+            return;
+          }
+          this.prepend(head, comments.get(commentData));
+        }, this);
+        return docObj;
       }.bind(this));
     }
     chain.then(function(docObj) {

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -195,19 +195,22 @@ Vulcan.prototype = {
     }
     this.pathResolver.acid(doc, tree.href);
     if (imports) {
-      for (var i = 0, im; i < imports.length; i++) {
+      for (var i = 0, im, thisImport; i < imports.length; i++) {
         im = imports[i];
+        thisImport = importNodes[i];
         if (this.isDuplicateImport(im)) {
-          this.removeImportAndNewline(importNodes[i]);
+          this.removeImportAndNewline(thisImport);
           continue;
         }
         if (this.isExcludedImport(im)) {
           continue;
         }
         if (this.isStrippedImport(im)) {
-          this.removeImportAndNewline(importNodes[i]);
+          this.removeImportAndNewline(thisImport);
           continue;
         }
+        // check if this import is a descendant of <body>
+        var importWasInBody = Boolean(dom5.nodeWalkPrior(thisImport, matchers.body));
         var importDoc = this.flatten(im, bodyFragment, mainDocUrl);
         // rewrite urls
         this.pathResolver.resolvePaths(importDoc, im.href, tree.href);
@@ -216,14 +219,19 @@ Vulcan.prototype = {
         // merge head and body tags for imports into main document
         var importHeadChildren = importHead.childNodes;
         var importBodyChildren = importBody.childNodes;
-        // delete link in head
-        this.removeImportAndNewline(importNodes[i]);
-        // defer head and body children to be inlined in-order
-        if (importHeadChildren.length) {
-          this.pathResolver.resolvePaths(importHead, tree.href, mainDocUrl);
-          importHeadChildren.forEach(this.reparent(bodyFragment));
-          bodyFragment.childNodes = bodyFragment.childNodes.concat(importHeadChildren);
+        if (importWasInBody) {
+          // delete link
+          this.removeImportAndNewline(thisImport);
+          // defer head children to be ordered properly in main document
+          if (importHeadChildren.length) {
+            this.pathResolver.resolvePaths(importHead, tree.href, mainDocUrl);
+            importHeadChildren.forEach(this.reparent(bodyFragment));
+            bodyFragment.childNodes = bodyFragment.childNodes.concat(importHeadChildren);
+          }
+        } else {
+          this.replaceWith(head, thisImport, importHeadChildren);
         }
+        // defer body children to be inlined in-order
         if (importBodyChildren.length) {
           // adjust body urls to main document
           this.pathResolver.resolvePaths(importBody, tree.href, mainDocUrl);
@@ -234,7 +242,6 @@ Vulcan.prototype = {
     }
     return doc;
   },
-
 
   prepend: function prepend(parent, node) {
     if (parent.childNodes.length) {

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -381,7 +381,6 @@ Vulcan.prototype = {
         return this.inlineCss(docObj.doc, docObj.href);
       }.bind(this));
     }
-
     if (this.stripComments) {
       chain = chain.then(function(docObj) {
         var comments = new CommentMap();

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -195,6 +195,8 @@ Vulcan.prototype = {
     }
     this.pathResolver.acid(doc, tree.href);
     if (imports) {
+      // flatten all of <head> into one list
+      var flatHead = dom5.queryAll(head, function(){ return true; });
       for (var i = 0, im, thisImport; i < imports.length; i++) {
         im = imports[i];
         thisImport = importNodes[i];
@@ -209,8 +211,6 @@ Vulcan.prototype = {
           this.removeImportAndNewline(thisImport);
           continue;
         }
-        // check if this import is a descendant of <body>
-        var importWasInBody = Boolean(dom5.nodeWalkPrior(thisImport, matchers.body));
         var importDoc = this.flatten(im, bodyFragment, mainDocUrl);
         // rewrite urls
         this.pathResolver.resolvePaths(importDoc, im.href, tree.href);
@@ -219,17 +219,13 @@ Vulcan.prototype = {
         // merge head and body tags for imports into main document
         var importHeadChildren = importHead.childNodes;
         var importBodyChildren = importBody.childNodes;
-        if (importWasInBody) {
-          // delete link
-          this.removeImportAndNewline(thisImport);
-          // defer head children to be ordered properly in main document
-          if (importHeadChildren.length) {
-            this.pathResolver.resolvePaths(importHead, tree.href, mainDocUrl);
-            importHeadChildren.forEach(this.reparent(bodyFragment));
-            bodyFragment.childNodes = bodyFragment.childNodes.concat(importHeadChildren);
-          }
-        } else {
-          this.replaceWith(head, thisImport, importHeadChildren);
+        // delete link
+        this.removeImportAndNewline(thisImport);
+        // defer head children to be ordered properly in main document
+        if (importHeadChildren.length) {
+          this.pathResolver.resolvePaths(importHead, tree.href, mainDocUrl);
+          importHeadChildren.forEach(this.reparent(bodyFragment));
+          bodyFragment.childNodes = bodyFragment.childNodes.concat(importHeadChildren);
         }
         // defer body children to be inlined in-order
         if (importBodyChildren.length) {
@@ -237,6 +233,24 @@ Vulcan.prototype = {
           this.pathResolver.resolvePaths(importBody, tree.href, mainDocUrl);
           importBodyChildren.forEach(this.reparent(bodyFragment));
           bodyFragment.childNodes = bodyFragment.childNodes.concat(importBodyChildren);
+        }
+        // to preserve script execution order, defer scripts after this import
+        // into body
+        var importInBody = Boolean(dom5.nodeWalkPrior(thisImport, matchers.body));
+        if (!importInBody) {
+          // only examine elements between this and the next import
+          var start = flatHead.indexOf(thisImport) + 1;
+          var end = flatHead.indexOf(importNodes[i + 1]);
+          if (end === -1) {
+            end = flatHead.length;
+          }
+          for (var headidx = start, el; headidx < end; headidx++) {
+            el = flatHead[headidx];
+            // if the element is a script, move it to bodyFragment
+            if (matchers.JS(el)) {
+              dom5.append(bodyFragment, el);
+            }
+          }
         }
       }
     }

--- a/test/html/comments.html
+++ b/test/html/comments.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- @license test -->
 <html lang="en">
 <head>
   <meta charset="UTF-8">

--- a/test/html/imports/body-import.html
+++ b/test/html/imports/body-import.html
@@ -11,6 +11,6 @@
 <script>
   'expected in head'
 </script>
-<div>
+<div id="imported">
   expected in body
 </div>

--- a/test/html/imports/comment-in-import.html
+++ b/test/html/imports/comment-in-import.html
@@ -1,2 +1,7 @@
+<!-- @license test -->
 <link rel="import" href="sub/second.html">
 <!-- comment in import -->
+<div>
+  <!-- @license test -->
+  <!-- comment in import -->
+</div>

--- a/test/html/order-test.html
+++ b/test/html/order-test.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title></title>
+  <script id="first-script" src="order/first-script.js"></script>
+  <link rel="import" href="order/first-import.html">
+  <script id="second-script" src="order/second-script.js"></script>
+</head>
+<body>
+  <script id="third-script" src="order/third-script.js"></script>
+</body>
+</html>

--- a/test/html/order/first-import.html
+++ b/test/html/order/first-import.html
@@ -1,0 +1,3 @@
+<script id="first-import-script">console.log('first-import-script')</script>
+<div></div>
+<script id="second-import-script">console.log('second-import-script')</script>

--- a/test/html/order/first-script.js
+++ b/test/html/order/first-script.js
@@ -1,0 +1,1 @@
+console.log('first-script');

--- a/test/html/order/second-script.js
+++ b/test/html/order/second-script.js
@@ -1,0 +1,1 @@
+console.log('second-script');

--- a/test/html/order/third-script.js
+++ b/test/html/order/third-script.js
@@ -1,0 +1,1 @@
+console.log('third-script');

--- a/test/html/reordered/first.html
+++ b/test/html/reordered/first.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<head>
+</head>
+<body>
+<script>"First"</script>
+</body>
+</html>

--- a/test/html/reordered/in.html
+++ b/test/html/reordered/in.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<head></head>
+<body>
+  <link rel="import" href="first.html">
+  <link rel="import" href="second.html">
+</body>
+</html>

--- a/test/html/reordered/second.html
+++ b/test/html/reordered/second.html
@@ -1,0 +1,1 @@
+<script>"Second"</script>

--- a/test/test.js
+++ b/test/test.js
@@ -383,6 +383,31 @@ suite('Vulcan', function() {
       });
     });
 
+    test('Imports and scripts are ordered correctly', function(done) {
+      var expected = [
+        'first-script',
+        'first-import-script',
+        'second-import-script',
+        'second-script',
+        'third-script'
+      ];
+
+      var scriptMatcher = preds.hasTagName('script');
+
+      var callback = function(err, doc) {
+        if (err) {
+          return done(err);
+        }
+        var scripts = dom5.queryAll(doc, scriptMatcher).map(function(s) {
+          return dom5.getAttribute(s, 'id');
+        });
+        assert.deepEqual(scripts, expected);
+        done();
+      };
+
+      process('test/html/order-test.html', callback);
+    });
+
     test('Old Polymer is detected and warns', function(done) {
       var constants = require('../lib/constants');
       var input = path.resolve('test/html/old-polymer.html');

--- a/test/test.js
+++ b/test/test.js
@@ -383,7 +383,7 @@ suite('Vulcan', function() {
       });
     });
 
-    test.skip('Imports and scripts are ordered correctly', function(done) {
+    test('Imports and scripts are ordered correctly', function(done) {
       var expected = [
         'first-script',
         'first-import-script',

--- a/test/test.js
+++ b/test/test.js
@@ -607,7 +607,7 @@ suite('Vulcan', function() {
         assert.equal(comments.length, 1);
         done();
       };
-      process(inputPath, callback, options);
+      process('test/html/comments.html', callback, options);
     });
 
     test('Comments are kept by default', function(done) {
@@ -619,9 +619,18 @@ suite('Vulcan', function() {
           return done(err);
         }
         var comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
-        assert.equal(comments.length, 2);
-        assert.equal(dom5.getTextContent(comments[0]).trim(), 'comment in import');
-        assert.equal(dom5.getTextContent(comments[1]).trim(), 'comment in main');
+        assert.equal(comments.length, 5);
+        var expectedComments = [
+          '@license test',
+          'comment in import',
+          '@license test',
+          'comment in import',
+          'comment in main'
+        ];
+        var actualComments = comments.map(function(c) {
+          return dom5.getTextContent(c).trim();
+        });
+        assert.deepEqual(expectedComments, actualComments);
         done();
       };
       process('test/html/comments.html', callback, options);

--- a/test/test.js
+++ b/test/test.js
@@ -605,6 +605,8 @@ suite('Vulcan', function() {
         }
         var comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
         assert.equal(comments.length, 1);
+        var commentActual = dom5.getTextContent(comments[0]).trim();
+        assert.equal('@license test', commentActual);
         done();
       };
       process('test/html/comments.html', callback, options);

--- a/test/test.js
+++ b/test/test.js
@@ -383,7 +383,7 @@ suite('Vulcan', function() {
       });
     });
 
-    test('Imports and scripts are ordered correctly', function(done) {
+    test.skip('Imports and scripts are ordered correctly', function(done) {
       var expected = [
         'first-script',
         'first-import-script',


### PR DESCRIPTION
All import portions, `<head>` and `<body>` will go into the body of the main
document. This is the only way to ensure that intra-import dependencies and
inter-import dependencies line up correctly.

Fixes #284