### PR TITLE
remove update-notifier dependency and support

### DIFF
--- a/bin/vulcanize
+++ b/bin/vulcanize
@@ -112,16 +112,6 @@ if (args.help || !target) {
   process.exit(0);
 }
 
-if (args['update-notifier'] !== false) {
-  (function() {
-    try {
-      require('update-notifier')({
-        pkg: pkg
-      }).notify();
-    } catch(_) {}
-  })();
-}
-
 // escape a regex string and return a new RegExp
 function stringToRegExp(str) {
   return new RegExp(str.replace(/[-\/\\*+?.()|[\]{}]/g, '\\$&'));

--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
   },
   "bugs": {
     "url": "https://github.com/Polymer/vulcanize/issues"
-  },
-  "optionalDependencies": {
-    "update-notifier": "^0.6.0"
   }
 }


### PR DESCRIPTION
It looks like this feature has been lost in time. No longer documented and opt-in only. Safe to remove support?

/cc @justinfagnani @azakus 