### PR TITLE
CSS Inlining

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "vulcanize": "bin/vulcanize"
   },
   "dependencies": {
-    "dom5": "^1.3.2",
+    "dom5": "^1.3.6",
     "es6-promise": "^2.1.0",
     "nopt": "^3.0.1",
     "parse5": "^2.2.1",
     "path-posix": "^1.0.0",
-    "polymer-analyzer": "^2.0.0-alpha.3"
+    "polymer-analyzer": "^2.0.0-alpha.4"
   },
   "devDependencies": {
     "@types/chai": "^3.4.30",

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -170,15 +170,6 @@ class Bundler {
   }
 
   /**
-   * Creates a <style> tag to which inlined content will be appended.
-   */
-  createInlineStyleNode() {
-    const styleNode = dom5.constructors.element('style');
-
-    return styleNode;
-  }
-
-  /**
    * Inline external scripts <script src="*">
    */
   inlineScript(
@@ -212,16 +203,16 @@ class Bundler {
     const stylesheetUrl: string = dom5.getAttribute(cssLink, 'href')!;
     const resolvedStylesheetUrl = url.resolve(docUrl, stylesheetUrl);
     const stylesheetImport = importMap.get(resolvedStylesheetUrl);
+
     if (!stylesheetImport || !stylesheetImport.document) {
       return;
     }
 
     const media = dom5.getAttribute(cssLink, 'media');
-
     const stylesheetContent = stylesheetImport.document.parsedDocument.contents;
     const resolvedStylesheetContent = this.rewriteImportedStyleTextUrls(
         resolvedStylesheetUrl, docUrl, stylesheetContent);
-    const styleNode = this.createInlineStyleNode();
+    const styleNode = dom5.constructors.element('style');
 
     if (media) {
       dom5.setAttribute(styleNode, 'media', media);
@@ -229,7 +220,6 @@ class Bundler {
 
     dom5.replace(cssLink, styleNode);
     dom5.setTextContent(styleNode, resolvedStylesheetContent);
-
     return styleNode;
   }
 

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -25,8 +25,6 @@ import {ASTNode, CommentNode} from 'parse5';
 import {Analyzer, Options as AnalyzerOptions} from 'polymer-analyzer';
 import {Document, ScannedDocument, Import} from 'polymer-analyzer/lib/ast/ast';
 import {ParsedHtmlDocument} from 'polymer-analyzer/lib/html/html-document';
-import {UrlLoader} from 'polymer-analyzer/lib/url-loader/url-loader';
-import {FSUrlLoader} from 'polymer-analyzer/lib/url-loader/fs-url-loader';
 import constants from './constants';
 import * as astUtils from './ast-utils';
 import * as matchers from './matchers';

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -55,6 +55,7 @@ export const targetMatcher: Matcher = predicates.AND(
 export const head: Matcher = predicates.hasTagName('head');
 export const body: Matcher = predicates.hasTagName('body');
 export const base: Matcher = predicates.hasTagName('base');
+export const template: Matcher = predicates.hasTagName('template');
 export const domModule: Matcher = predicates.AND(
     predicates.hasTagName('dom-module'), predicates.hasAttr('id'),
     predicates.NOT(predicates.hasAttr('assetpath')));

--- a/test/html/imports/remote-stylesheet.html
+++ b/test/html/imports/remote-stylesheet.html
@@ -10,4 +10,4 @@
 <!-- Roboto Font on Google Font CDN -->
 <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic,500,500italic,700,700italic">
 
-<link rel="stylesheet" href="imports/regular-style.css" media="(min-width: 800px)">
+<link rel="stylesheet" href="regular-style.css" media="(min-width: 800px)">


### PR DESCRIPTION
CSS inlining is now implemented and works nearly identically as before.  I made one change in behavior, which was to move media query from `<link media="*">` tag directly to `<style media="*">` because cleaner.
