### PR TITLE
Support stripping inlined javascript

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -314,6 +314,10 @@ Vulcan.prototype = {
       var src = dom5.getAttribute(script, 'src');
       var uri = url.resolve(href, src);
       // let the loader handle the requests
+      if (this.isStripExcludedHref(src)) {
+        dom5.remove(script);
+        return Promise.resolve(true);
+      }
       if (this.isExcludedHref(src)) {
         return Promise.resolve(true);
       }


### PR DESCRIPTION
Projects with complex builds might want to exclude javascript(such as polyfills that a dependency erroneously brings in).