### PR TITLE
Changes to .clang-format around function parameters, to try and get them on their own lines once they exceed single line.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,10 @@
 BasedOnStyle: Google
+AlignAfterOpenBracket: AlwaysBreak
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-BinPackParameters: true
-BinPackArguments: true
+BinPackArguments: false
+BinPackParameters: false


### PR DESCRIPTION
Here's what it would do to the current v3 branch, for example:

```diff
diff --git a/src/bundler.ts b/src/bundler.ts
index 2c9fd14..0686e74 100644
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -172,7 +172,8 @@ class Bundler {
    * Inline external scripts <script src="*">
    */
   inlineScript(
-      docUrl: string, externalScript: ASTNode,
+      docUrl: string,
+      externalScript: ASTNode,
       importMap: Map<string, Import|null>): ASTNode|undefined {
     const rawUrl: string = dom5.getAttribute(externalScript, 'src')!;
     const resolvedUrl = url.resolve(docUrl, rawUrl);
@@ -197,7 +198,8 @@ class Bundler {
    * `<link rel="stylesheet">`.
    */
   inlineStylesheet(
-      docUrl: string, cssLink: ASTNode,
+      docUrl: string,
+      cssLink: ASTNode,
       importMap: Map<string, Import|null>): ASTNode|undefined {
     const stylesheetUrl: string = dom5.getAttribute(cssLink, 'href')!;
     const resolvedStylesheetUrl = url.resolve(docUrl, stylesheetUrl);
@@ -228,7 +230,8 @@ class Bundler {
    *     for hidden div adjacency etc.
    */
   inlineHtmlImport(
-      docUrl: string, htmlImport: ASTNode,
+      docUrl: string,
+      htmlImport: ASTNode,
       importMap: Map<string, Import|null>) {
     const rawUrl: string = dom5.getAttribute(htmlImport, 'href')!;
     const resolvedUrl: string = url.resolve(docUrl, rawUrl);
@@ -304,7 +307,9 @@ class Bundler {
   }
 
   rewriteImportedStyleTextUrls(
-      importUrl: string, mainDocUrl: string, cssText: string): string {
+      importUrl: string,
+      mainDocUrl: string,
+      cssText: string): string {
     return cssText.replace(constants.URL, match => {
       let path = match.replace(/["']/g, '').slice(4, -1);
       path = urlUtils.rewriteImportedRelPath(
@@ -314,7 +319,9 @@ class Bundler {
   }
 
   rewriteImportedUrls(
-      importDoc: ASTNode, importUrl: string, mainDocUrl: string) {
+      importDoc: ASTNode,
+      importUrl: string,
+      mainDocUrl: string) {
     // rewrite URLs in element attributes
     const nodes = dom5.queryAll(importDoc, matchers.urlAttrs);
     let attrValue: string|null;
diff --git a/src/matchers.ts b/src/matchers.ts
index 6153a8b..4b0dff6 100644
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -39,7 +39,8 @@ export const externalStyle: Matcher = predicates.AND(
     predicates.hasAttrValue('rel', 'stylesheet'));
 // polymer specific external stylesheet
 export const polymerExternalStyle: Matcher = predicates.AND(
-    predicates.hasTagName('link'), predicates.hasAttrValue('rel', 'import'),
+    predicates.hasTagName('link'),
+    predicates.hasAttrValue('rel', 'import'),
     predicates.hasAttrValue('type', 'css'));
 
 export const styleMatcher: Matcher = predicates.AND(
@@ -57,7 +58,8 @@ export const body: Matcher = predicates.hasTagName('body');
 export const base: Matcher = predicates.hasTagName('base');
 export const template: Matcher = predicates.hasTagName('template');
 export const domModule: Matcher = predicates.AND(
-    predicates.hasTagName('dom-module'), predicates.hasAttr('id'),
+    predicates.hasTagName('dom-module'),
+    predicates.hasAttr('id'),
     predicates.NOT(predicates.hasAttr('assetpath')));
 export const meta: Matcher = predicates.AND(
     predicates.hasTagName('meta'), predicates.hasAttr('charset'));
@@ -67,17 +69,21 @@ export const externalJavascript: Matcher =
 export const inlineJavascript: Matcher =
     predicates.AND(predicates.NOT(predicates.hasAttr('src')), jsMatcher);
 export const htmlImport: Matcher = predicates.AND(
-    predicates.hasTagName('link'), predicates.hasAttrValue('rel', 'import'),
+    predicates.hasTagName('link'),
+    predicates.hasAttrValue('rel', 'import'),
     predicates.hasAttr('href'),
     predicates.OR(
         predicates.hasAttrValue('type', 'text/html'),
         predicates.hasAttrValue('type', 'html'),
         predicates.NOT(predicates.hasAttr('type'))));
 export const stylesheetImport: Matcher = predicates.AND(
-    predicates.hasTagName('link'), predicates.hasAttrValue('rel', 'import'),
-    predicates.hasAttr('href'), predicates.hasAttrValue('type', 'css'));
+    predicates.hasTagName('link'),
+    predicates.hasAttrValue('rel', 'import'),
+    predicates.hasAttr('href'),
+    predicates.hasAttrValue('type', 'css'));
 export const hiddenDiv = predicates.AND(
-    predicates.hasTagName('div'), predicates.hasAttr('hidden'),
+    predicates.hasTagName('div'),
+    predicates.hasAttr('hidden'),
     predicates.hasAttr('by-vulcanize'));
 
 export const inHiddenDiv = predicates.parentMatches(hiddenDiv);
diff --git a/src/test/bundle-manifest_test.ts b/src/test/bundle-manifest_test.ts
index 7000a34..914c255 100644
--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -112,8 +112,14 @@ suite('BundleManifest', () => {
   suite('BundleStrategy', () => {
 
     const bundles: Bundle[] = [
-      '[A]->[A,1]', '[A,B]->[2]', '[A,B,C]->[3]', '[B]->[B,4]', '[B,C]->[5]',
-      '[B,C,D]->[6]', '[C]->[C,7]', '[D]->[D,8]'
+      '[A]->[A,1]',
+      '[A,B]->[2]',
+      '[A,B,C]->[3]',
+      '[B]->[B,4]',
+      '[B,C]->[5]',
+      '[B,C,D]->[6]',
+      '[C]->[C,7]',
+      '[D]->[D,8]'
     ].map(deserializeBundle);
 
     suite('generateSharedDepsMergeStrategy', () => {
@@ -168,14 +174,18 @@ suite('BundleManifest', () => {
       const depsIndex: TransitiveDependenciesMap = new Map();
 
       depsIndex.set('app-shell.html', new Set(['app-shell.html']));
-      depsIndex.set(
-          'catalog-list.html', new Set([
-            'catalog-list.html', 'tin-photo.html', 'tin-add-to-cart.html',
-            'tin-caption.html', 'tin-paginator.html'
-          ]));
+      depsIndex.set('catalog-list.html', new Set([
+                      'catalog-list.html',
+                      'tin-photo.html',
+                      'tin-add-to-cart.html',
+                      'tin-caption.html',
+                      'tin-paginator.html'
+                    ]));
       depsIndex.set('catalog-item.html', new Set([
-                      'catalog-item.html', 'tin-photo.html',
-                      'tin-add-to-cart.html', 'tin-gallery.html'
+                      'catalog-item.html',
+                      'tin-photo.html',
+                      'tin-add-to-cart.html',
+                      'tin-gallery.html'
                     ]));
       depsIndex.set(
           'cart.html',
diff --git a/src/test/bundler_test.ts b/src/test/bundler_test.ts
index 77aae84..c2354b8 100644
--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -50,8 +50,10 @@ suite('Bundler', () => {
   suite('Default Options', () => {
     test('imports removed', () => {
       const imports = preds.AND(
-          preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'),
-          preds.hasAttr('href'), preds.NOT(preds.hasAttrValue('type', 'css')));
+          preds.hasTagName('link'),
+          preds.hasAttrValue('rel', 'import'),
+          preds.hasAttr('href'),
+          preds.NOT(preds.hasAttrValue('type', 'css')));
       return bundle(inputPath).then((doc) => {
         assert.equal(dom5.queryAll(doc, imports).length, 0);
       });
@@ -114,7 +116,8 @@ suite('Bundler', () => {
         preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'));
 
     const bodyContainerMatcher = preds.AND(
-        preds.hasTagName('div'), preds.hasAttr('hidden'),
+        preds.hasTagName('div'),
+        preds.hasAttr('hidden'),
         preds.hasAttr('by-vulcanize'));
 
     const scriptExpected = preds.hasTagName('script');
@@ -164,15 +167,27 @@ suite('Bundler', () => {
 
     test('Rewrite URLs', () => {
       const css = [
-        'x-element {', '  background-image: url(foo.jpg);', '}', 'x-bar {',
-        '  background-image: url(data:xxxxx);', '}', 'x-quuz {',
-        '  background-image: url(\'https://foo.bar/baz.jpg\');', '}'
+        'x-element {',
+        '  background-image: url(foo.jpg);',
+        '}',
+        'x-bar {',
+        '  background-image: url(data:xxxxx);',
+        '}',
+        'x-quuz {',
+        '  background-image: url(\'https://foo.bar/baz.jpg\');',
+        '}'
       ].join('\n');
 
       const expected = [
-        'x-element {', '  background-image: url("my-element/foo.jpg");', '}',
-        'x-bar {', '  background-image: url("data:xxxxx");', '}', 'x-quuz {',
-        '  background-image: url("https://foo.bar/baz.jpg");', '}'
+        'x-element {',
+        '  background-image: url("my-element/foo.jpg");',
+        '}',
+        'x-bar {',
+        '  background-image: url("data:xxxxx");',
+        '}',
+        'x-quuz {',
+        '  background-image: url("https://foo.bar/baz.jpg");',
+        '}'
       ].join('\n');
 
       const bundler = new Bundler();
@@ -185,10 +200,13 @@ suite('Bundler', () => {
       const html = [
         '<link rel="import" href="../polymer/polymer.html">',
         '<link rel="stylesheet" href="my-element.css">',
-        '<dom-module id="my-element">', '<template>',
+        '<dom-module id="my-element">',
+        '<template>',
         '<style>:host { background-image: url(background.svg); }</style>',
-        '<div style="position: absolute;"></div>', '</template>',
-        '</dom-module>', '<script>Polymer({is: "my-element"})</script>'
+        '<div style="position: absolute;"></div>',
+        '</template>',
+        '</dom-module>',
+        '<script>Polymer({is: "my-element"})</script>'
       ].join('\n');
 
       const expected = [
@@ -197,7 +215,8 @@ suite('Bundler', () => {
         '</head><body><dom-module id="my-element" assetpath="my-element/">',
         '<template>',
         '<style>:host { background-image: url("my-element/background.svg"); }</style>',
-        '<div style="position: absolute;"></div>', '</template>',
+        '<div style="position: absolute;"></div>',
+        '</template>',
         '</dom-module>',
         '<script>Polymer({is: "my-element"})</script></body></html>'
       ].join('\n');
@@ -215,9 +234,11 @@ suite('Bundler', () => {
         '<base href="zork">',
         '<link rel="import" href="../polymer/polymer.html">',
         '<link rel="stylesheet" href="my-element.css">',
-        '<dom-module id="my-element">', '<template>',
+        '<dom-module id="my-element">',
+        '<template>',
         '<style>:host { background-image: url(background.svg); }</style>',
-        '</template>', '</dom-module>',
+        '</template>',
+        '</dom-module>',
         '<script>Polymer({is: "my-element"})</script>'
       ].join('\n');
 
@@ -228,7 +249,8 @@ suite('Bundler', () => {
         '</head><body><dom-module id="my-element" assetpath="my-element/zork/">',
         '<template>',
         '<style>:host { background-image: url("my-element/zork/background.svg"); }</style>',
-        '</template>', '</dom-module>',
+        '</template>',
+        '</dom-module>',
         '<script>Polymer({is: "my-element"})</script></body></html>'
       ].join('\n');
 
@@ -246,9 +268,11 @@ suite('Bundler', () => {
         '<base href="zork/">',
         '<link rel="import" href="../polymer/polymer.html">',
         '<link rel="stylesheet" href="my-element.css">',
-        '<dom-module id="my-element">', '<template>',
+        '<dom-module id="my-element">',
+        '<template>',
         '<style>:host { background-image: url(background.svg); }</style>',
-        '</template>', '</dom-module>',
+        '</template>',
+        '</dom-module>',
         '<script>Polymer({is: "my-element"})</script>'
       ].join('\n');
 
@@ -293,8 +317,10 @@ suite('Bundler', () => {
 
     test('Leave Templated URLs', () => {
       const base = [
-        '<html><head></head><body>', '<a href="{{foo}}"></a>',
-        '<img src="[[bar]]">', '</body></html>'
+        '<html><head></head><body>',
+        '<a href="{{foo}}"></a>',
+        '<img src="[[bar]]">',
+        '</body></html>'
       ].join('\n');
 
       const ast = dom5.parse(base);
@@ -331,16 +357,22 @@ suite('Bundler', () => {
     test('Imports and scripts are ordered correctly', () => {
       return bundle('test/html/order-test.html').then((doc) => {
         const expectedOrder = [
-          'first-script', 'second-import-first-script',
-          'second-import-second-script', 'first-import-first-script',
-          'first-import-second-script', 'second-script', 'third-script'
+          'first-script',
+          'second-import-first-script',
+          'second-import-second-script',
+          'first-import-first-script',
+          'first-import-second-script',
+          'second-script',
+          'third-script'
         ];
 
         const expectedSrc = [
-          'order/first-script.js', 'order/second-import/first-script.js',
+          'order/first-script.js',
+          'order/second-import/first-script.js',
           'order/second-import/second-script.js',
           'order/first-import/first-script.js',
-          'order/first-import/second-script.js', 'order/second-script.js',
+          'order/first-import/second-script.js',
+          'order/second-script.js',
           'order/third-script.js'
         ];
 
@@ -393,7 +425,8 @@ suite('Bundler', () => {
           preds.hasTagName('dom-module'),
           preds.hasAttrValue('assetpath', '/html/imports/'));
       const stylesheet = preds.AND(
-          preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'),
+          preds.hasTagName('link'),
+          preds.hasAttrValue('rel', 'import'),
           preds.hasAttrValue('type', 'css'),
           preds.hasAttrValue('href', '/html/imports/simple-style.css'));
       return bundle(target, options).then((doc) => {
@@ -422,7 +455,8 @@ suite('Bundler', () => {
         preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'));
 
     const excluded = preds.AND(
-        preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'),
+        preds.hasTagName('link'),
+        preds.hasAttrValue('rel', 'import'),
         preds.hasAttrValue('href', 'imports/simple-import.html'));
 
     const excludes = ['test/html/imports/simple-import.html'];
@@ -437,7 +471,8 @@ suite('Bundler', () => {
     });
 
     const cssFromExclude = preds.AND(
-        preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'),
+        preds.hasTagName('link'),
+        preds.hasAttrValue('rel', 'import'),
         preds.hasAttrValue('type', 'css'));
 
     // TODO(ajo): Fix test with hydrolysis upgrades.
@@ -506,8 +541,12 @@ suite('Bundler', () => {
       return bundle('test/html/comments.html', options).then((doc) => {
         const comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
         const expectedComments = [
-          '@license main', '@license import 1', 'comment in import 1',
-          '@license import 2', 'comment in import 2', 'comment in main'
+          '@license main',
+          '@license import 1',
+          'comment in import 1',
+          '@license import 2',
+          'comment in import 2',
+          'comment in main'
         ];
         const actualComments = comments.map(function(c) {
           return dom5.getTextContent(c).trim();
@@ -727,7 +766,8 @@ suite('Bundler', () => {
     test.skip('Imports in templates should not inline', () => {
       return bundle('test/html/inside-template.html').then((doc) => {
         const importMatcher = preds.AND(
-            preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'),
+            preds.hasTagName('link'),
+            preds.hasAttrValue('rel', 'import'),
             preds.hasAttr('href'));
         const externalScriptMatcher = preds.AND(
             preds.hasTagName('script'),
@@ -737,7 +777,8 @@ suite('Bundler', () => {
         assert.equal(imports.length, 1, 'import in template was inlined');
         const unexpectedScript = dom5.query(doc, externalScriptMatcher);
         assert.equal(
-            unexpectedScript, null,
+            unexpectedScript,
+            null,
             'script in external.html should not be present');
       });
     });
diff --git a/src/url-utils.ts b/src/url-utils.ts
index 2eb0d99..57b2adc 100644
--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -69,7 +69,9 @@ export function relativeUrl(fromUri: string, toUri: string): string {
 // href.  If `basePath` is defined, it rewrites the path as an absolute path
 // using `basePath` as its root.
 export function rewriteImportedRelPath(
-    basePath: string|undefined, importUrl: string, mainDocUrl: string,
+    basePath: string|undefined,
+    importUrl: string,
+    mainDocUrl: string,
     href: string): string {
   if (isAbsolutePath(href)) {
     return href;
```