### PR TITLE
Peg analyzer at 2.0.0-alpha.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "nopt": "^3.0.1",
     "parse5": "^2.2.1",
     "path-posix": "^1.0.0",
-    "polymer-analyzer": "^2.0.0-alpha.4"
+    "polymer-analyzer": "2.0.0-alpha.7"
   },
   "devDependencies": {
     "@types/chai": "^3.4.30",


### PR DESCRIPTION
analyzeRoot was removed and that's breaking build.  Fixing by pegging polymer-analyzer package at last-known compatible version.