### PR TITLE
assetpath in same directory fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- New PRs should document their changes here. -->
 
+## 1.14.12 - 2016-11-01
+- Fix for how assetpath is set when in the same directory.
+
 ## 1.14.11 - 2016-04-11
 - Radically simpler inlining design. Move all imports and scripts into document
   body, replace imports inline.

--- a/lib/pathresolver.js
+++ b/lib/pathresolver.js
@@ -45,7 +45,7 @@ PathResolver.prototype = {
             relUrl = this.rewriteURL(importUrl, mainDocUrl, attrValue);
           } else {
             relUrl = this.rewriteRelPath(importUrl, mainDocUrl, attrValue);
-            if (attr === 'assetpath' && relUrl.slice(-1) !== '/') {
+            if (attr === 'assetpath' && relUrl.length > 0 && relUrl.slice(-1) !== '/') {
               relUrl += '/';
             }
           }

--- a/test/test.js
+++ b/test/test.js
@@ -265,6 +265,29 @@ suite('Path Resolver', function() {
     assert.equal(actual, base, 'templated urls');
   });
 
+  test('Rewrite assetpath in same directory', function() {
+    var html = [
+      '<dom-module id="my-element" assetpath="./">',
+      '<template>',
+      '</template>',
+      '</dom-module>',
+      '<script>Polymer({is: "my-element"})</script>'
+    ].join('\n');
+
+    var expected = [
+      '<html><head></head><body><dom-module id="my-element" assetpath="">',
+      '<template>',
+      '</template>',
+      '</dom-module>',
+      '<script>Polymer({is: "my-element"})</script></body></html>'
+    ].join('\n');
+
+    var ast = parse(html);
+    pathresolver.resolvePaths(ast, inputPath, inputPath);
+
+    var actual = serialize(ast);
+    assert.equal(actual, expected, 'relative');
+  });
 });
 
 suite('Vulcan', function() {


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

Fix to Issue #368. This issue occurs when the entry point file imports a component from the same directory, the assetpath attribute for the component gets set to '/', this in turn results in the wrong value being returned from the resolveUrl function.

The fix makes it so the assetpath is set to an empty string. Could also be './' I wasn't sure which would be best. 